### PR TITLE
[BREAKING] refactor: use `postcss-advanced-variables`

### DIFF
--- a/lib/clark-plugin.js
+++ b/lib/clark-plugin.js
@@ -45,7 +45,9 @@ module.exports = class ClarkPlugin extends Plugin {
       // @if, @else and @else if
       // Iterate over numeric ranges with @for
       // Iterate over lists with @each
-      require('postcss-advanced-variables'),
+      require('postcss-advanced-variables', {
+        disable: '@mixin, @include, @content'
+      }),
 
       // https://github.com/jonathantneal/postcss-short
       // Shorthand properties

--- a/lib/clark-plugin.js
+++ b/lib/clark-plugin.js
@@ -46,7 +46,8 @@ module.exports = class ClarkPlugin extends Plugin {
       // Iterate over numeric ranges with @for
       // Iterate over lists with @each
       require('postcss-advanced-variables')({
-        disable: '@mixin, @include, @content'
+        disable: '@mixin, @include, @content',
+        unresolved: 'ignore'
       }),
 
       // https://github.com/jonathantneal/postcss-short

--- a/lib/clark-plugin.js
+++ b/lib/clark-plugin.js
@@ -45,7 +45,7 @@ module.exports = class ClarkPlugin extends Plugin {
       // @if, @else and @else if
       // Iterate over numeric ranges with @for
       // Iterate over lists with @each
-      require('postcss-advanced-variables', {
+      require('postcss-advanced-variables')({
         disable: '@mixin, @include, @content'
       }),
 

--- a/lib/clark-plugin.js
+++ b/lib/clark-plugin.js
@@ -14,7 +14,7 @@ module.exports = class ClarkPlugin extends Plugin {
     return (this.project.targets && this.project.targets.browsers) || null;
   }
 
-  config(env, baseConfig) {
+  config(environment, baseConfig) {
     const before = [
       // https://github.com/postcss/postcss-mixins
       // Use @define-mixin and @mixin rules
@@ -41,17 +41,11 @@ module.exports = class ClarkPlugin extends Plugin {
       // Nest rules and reference the parent via &
       require('postcss-nested'),
 
-      // https://github.com/outpunk/postcss-each
-      // Iterate over lists with @each
-      require('postcss-each'),
-
-      // https://github.com/antyakushev/postcss-for
-      // Iterate over numeric ranges with @for
-      require('postcss-for'),
-
-      // https://github.com/andyjansson/postcss-conditionals
+      // https://github.com/jonathantneal/postcss-advanced-variables
       // @if, @else and @else if
-      require('postcss-conditionals'),
+      // Iterate over numeric ranges with @for
+      // Iterate over lists with @each
+      require('postcss-advanced-variables'),
 
       // https://github.com/jonathantneal/postcss-short
       // Shorthand properties

--- a/package.json
+++ b/package.json
@@ -19,13 +19,11 @@
     "start": "ember serve"
   },
   "dependencies": {
+    "postcss-advanced-variables": "^3.0.0",
     "postcss-calc": "^7.0.1",
     "postcss-color-function": "^4.1.0",
-    "postcss-conditionals": "^2.1.0",
     "postcss-custom-selectors": "^5.1.2",
-    "postcss-each": "^0.10.0",
     "postcss-easing-gradients": "^3.0.1",
-    "postcss-for": "^2.1.1",
     "postcss-hexrgba": "^1.0.2",
     "postcss-mixins": "^6.2.2",
     "postcss-nested": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -735,6 +735,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@csstools/sass-import-resolve@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@csstools/sass-import-resolve/-/sass-import-resolve-1.0.0.tgz#32c3cdb2f7af3cd8f0dca357b592e7271f3831b5"
+  integrity sha512-pH4KCsbtBLLe7eqUrw8brcuFO8IZlN36JjdKlOublibVdAIPHCzEnpBWOVUXK5sCf+DpBi8ZtuWtjF0srybdeA==
+
 "@ember/optional-features@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@ember/optional-features/-/optional-features-0.7.0.tgz#f65a858007020ddfb8342f586112750c32abd2d9"
@@ -2598,11 +2603,6 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^0.5.2:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
-  integrity sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=
-
 color-convert@^1.3.0, color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -2878,14 +2878,6 @@ css-blank-pseudo@^0.1.4:
   dependencies:
     postcss "^7.0.5"
 
-css-color-converter@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/css-color-converter/-/css-color-converter-1.1.0.tgz#c2e7d93c2e96c8ad8cb1ac7a1f2e49d8052ade36"
-  integrity sha1-wufZPC6WyK2Msax6Hy5J2AUq3jY=
-  dependencies:
-    color-convert "^0.5.2"
-    color-name "^1.0.0"
-
 css-color-function@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/css-color-function/-/css-color-function-1.3.3.tgz#8ed24c2c0205073339fafa004bc8c141fccb282e"
@@ -2920,7 +2912,7 @@ css-selector-tokenizer@^0.7.0:
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
 
-css-unit-converter@^1.0.0, css-unit-converter@^1.1.1:
+css-unit-converter@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/css-unit-converter/-/css-unit-converter-1.1.1.tgz#d9b9281adcfd8ced935bdbaba83786897f64e996"
   integrity sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=
@@ -4668,11 +4660,6 @@ has-cors@1.1.0:
   resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
   integrity sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=
 
-has-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
-  integrity sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
-
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -5268,11 +5255,6 @@ jquery@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
-
-js-base64@^2.1.9:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
-  integrity sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
 
 js-levenshtein@^1.1.3:
   version "1.1.6"
@@ -6483,6 +6465,14 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+postcss-advanced-variables@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-advanced-variables/-/postcss-advanced-variables-3.0.0.tgz#d1ca9a0da920c0be41213dd33ce6033d14f0b150"
+  integrity sha512-e5tcG0+l2qaqV65+qQCAW91vX4+mYbh2m5tdBYrzOhYjFgtNmtehmZWotvzWTGbtgbP11tgGirEYy2P7m6HceQ==
+  dependencies:
+    "@csstools/sass-import-resolve" "^1.0.0"
+    postcss "^7.0.6"
+
 postcss-attribute-case-insensitive@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.1.tgz#b2a721a0d279c2f9103a36331c88981526428cc7"
@@ -6553,15 +6543,6 @@ postcss-color-rebeccapurple@^4.0.1:
     postcss "^7.0.2"
     postcss-values-parser "^2.0.0"
 
-postcss-conditionals@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-conditionals/-/postcss-conditionals-2.1.0.tgz#4d1f62aa540458ce7ab779f71656901c8f8e929a"
-  integrity sha1-TR9iqlQEWM56t3n3FlaQHI+Okpo=
-  dependencies:
-    css-color-converter "^1.0.2"
-    css-unit-converter "^1.0.0"
-    postcss "^5.0.4"
-
 postcss-custom-media@^7.0.8:
   version "7.0.8"
   resolved "https://registry.yarnpkg.com/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz#fffd13ffeffad73621be5f387076a28b00294e0c"
@@ -6600,14 +6581,6 @@ postcss-double-position-gradients@^1.0.0:
   dependencies:
     postcss "^7.0.5"
     postcss-values-parser "^2.0.0"
-
-postcss-each@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/postcss-each/-/postcss-each-0.10.0.tgz#0877c6aea504bffd8a5d1f789d47d06a3e5feea1"
-  integrity sha1-CHfGrqUEv/2KXR94nUfQaj5f7qE=
-  dependencies:
-    postcss "^6.0.1"
-    postcss-simple-vars "^4.0.0"
 
 postcss-easing-gradients@^3.0.1:
   version "3.0.1"
@@ -6654,14 +6627,6 @@ postcss-font-weights@^5.0.0:
   integrity sha512-n/1sLibDcRcFS4HcGVzB81eUdxjG8p3XZFvM3Q+0Szz+e8f64dV3bJyUMs7Nw8ZV4qmO293SUVmOMmmhNMkzjw==
   dependencies:
     postcss "^7.0.5"
-
-postcss-for@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/postcss-for/-/postcss-for-2.1.1.tgz#841378c0ef909d50e1980d5aa71e6a340e728fcd"
-  integrity sha1-hBN4wO+QnVDhmA1apx5qNA5yj80=
-  dependencies:
-    postcss "^5.0.0"
-    postcss-simple-vars "^2.0.0"
 
 postcss-gap-properties@^2.0.0:
   version "2.0.0"
@@ -7010,20 +6975,6 @@ postcss-short@^5.0.0:
     postcss-short-size "^4.0.0"
     postcss-short-spacing "^4.0.0"
 
-postcss-simple-vars@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-simple-vars/-/postcss-simple-vars-2.0.0.tgz#d0a1091b0da22b79507028f7b22b976c0a60b8d5"
-  integrity sha1-0KEJGw2iK3lQcCj3siuXbApguNU=
-  dependencies:
-    postcss "^5.0.21"
-
-postcss-simple-vars@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-simple-vars/-/postcss-simple-vars-4.1.0.tgz#043248cfef8d3f51b3486a28c09f8375dbf1b2f9"
-  integrity sha512-J/TRomA8EqXhS4VjQJsPCYTFIa9FYN/dkJK/8oZ0BYeVIPx91goqM8T+ljsP57+4bwSEywFOuB7EZ8n1gjjxZw==
-  dependencies:
-    postcss "^6.0.9"
-
 postcss-simple-vars@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/postcss-simple-vars/-/postcss-simple-vars-5.0.2.tgz#e2f81b3d0847ddd4169816b6d141b91d51e6e22e"
@@ -7050,17 +7001,7 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss@^5.0.0, postcss@^5.0.21, postcss@^5.0.4:
-  version "5.2.18"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
-  integrity sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==
-  dependencies:
-    chalk "^1.1.3"
-    js-base64 "^2.1.9"
-    source-map "^0.5.6"
-    supports-color "^3.2.3"
-
-postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.19, postcss@^6.0.23, postcss@^6.0.6, postcss@^6.0.7, postcss@^6.0.9:
+postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.19, postcss@^6.0.23, postcss@^6.0.6, postcss@^6.0.7:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
   integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
@@ -8128,13 +8069,6 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
-
-supports-color@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
-  integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
-  dependencies:
-    has-flag "^1.0.0"
 
 supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.5.0"


### PR DESCRIPTION
Adding: postcss-advanced-variables
Remove: postcss-each, postcss-for, postcss-conditionals

I disabled `@mixin, @include, @content` as I guess it would conflict with `postcss-mixins`.

Open question here: We might think about using `postcss-advanced-variables` instead of `postcss-mixins`, but those from `advanced-variables` package feel less capable.