### PR TITLE
remove postcss-calc

### DIFF
--- a/lib/clark-plugin.js
+++ b/lib/clark-plugin.js
@@ -60,10 +60,6 @@ module.exports = class ClarkPlugin extends Plugin {
       // require('postcss-property-lookup')
     ];
     const after = [
-      // https://github.com/postcss/postcss-calc
-      // Reduce `calc()` expressions whenever possible
-      require('postcss-calc'),
-
       // https://github.com/postcss/postcss-color-function
       // Transform W3C CSS color function to more compatible CSS
       require('postcss-color-function'),

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "postcss-advanced-variables": "^3.0.0",
-    "postcss-calc": "^7.0.1",
     "postcss-color-function": "^4.1.0",
     "postcss-custom-selectors": "^5.1.2",
     "postcss-easing-gradients": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3303,11 +3303,6 @@ css-selector-tokenizer@^0.7.0:
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
 
-css-unit-converter@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/css-unit-converter/-/css-unit-converter-1.1.1.tgz#d9b9281adcfd8ced935bdbaba83786897f64e996"
-  integrity sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=
-
 cssdb@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/cssdb/-/cssdb-4.4.0.tgz#3bf2f2a68c10f5c6a08abd92378331ee803cddb0"
@@ -7088,16 +7083,6 @@ postcss-attribute-case-insensitive@^4.0.1:
   dependencies:
     postcss "^7.0.2"
     postcss-selector-parser "^5.0.0"
-
-postcss-calc@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-7.0.1.tgz#36d77bab023b0ecbb9789d84dcb23c4941145436"
-  integrity sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==
-  dependencies:
-    css-unit-converter "^1.1.1"
-    postcss "^7.0.5"
-    postcss-selector-parser "^5.0.0-rc.4"
-    postcss-value-parser "^3.3.1"
 
 postcss-color-function@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Remove `postcss-calc` as it pre-calculates formula that are meant to be evaluated by a browser. Second (form their example itself) it destroys CSS. It evaluates css custom properties, that can be changed by the cascade. This is eliminated.

I see no risk in removing this as everything will fallback to browsers evaluating `calc()` expressions.